### PR TITLE
Fixes for Project Creation

### DIFF
--- a/tools/project_creation.py
+++ b/tools/project_creation.py
@@ -17,10 +17,9 @@ class ProjectCreation(BaseConfig):
             config.project_name, config.syglass_directory, 
             config.shader_settings_to_load_path, config.annotation_csv_file_path, config.trace_file_path
         )
-    
-    def create_base_project(self, first_img_image):
+
+    def create_project_from_first_image(self, first_img_image, proj_file_location):
         # create project in specified path
-        proj_file_location = r'{}'.format(self.output_path)
         project = pyglass.CreateProject(pyglass.path(proj_file_location), self.project_name)
 
         # import image data into project    
@@ -45,7 +44,7 @@ class ProjectCreation(BaseConfig):
                 time.sleep(0.1)
                 pbar.update(cd.GetPercentage() - pbar.n)
 
-        project_file_location = os.path.join(proj_file_location, self.project_name)
+    def set_voxel_dimensions(self, proj_file_location):
         proj_file_path = os.path.join(proj_file_location, self.project_name, f'{self.project_name}.syg')
         project = sy.get_project(proj_file_path)
 
@@ -55,7 +54,12 @@ class ProjectCreation(BaseConfig):
         img_res = img_res[::-1] 
         
         project.set_voxel_dimensions(img_res, dtype=float)
-        
+    
+    def create_base_project(self, first_img_image):
+        proj_file_location = r'{}'.format(self.output_path)
+        self.create_project_from_first_image(first_img_image, proj_file_location)
+        self.set_voxel_dimensions(proj_file_location)
+        project_file_location = os.path.join(proj_file_location, self.project_name)
         return project_file_location
     
     def add_mask_layer(self, proj_file_location, first_seg_image):

--- a/tools/project_creation.py
+++ b/tools/project_creation.py
@@ -1,3 +1,4 @@
+from cloudvolume import CloudVolume
 from config.base_config import BaseConfig
 from syglass import pyglass
 import time
@@ -48,7 +49,7 @@ class ProjectCreation(BaseConfig):
         proj_file_path = os.path.join(proj_file_location, self.project_name, f'{self.project_name}.syg')
         project = sy.get_project(proj_file_path)
 
-        img_vol = CloudVolume(self.img_uri, mip=self.img_res, fill_missing=True, progress=False, use_https=True)
+        img_vol = CloudVolume(f"s3://bossdb-open-data/{self.img_uri}", mip=self.img_res, fill_missing=True, progress=False, use_https=True)
         img_res = np.array(img_vol.resolution)
         # reverse it to [Z, Y, X] to match syGlass
         img_res = img_res[::-1] 

--- a/tools/project_creation.py
+++ b/tools/project_creation.py
@@ -54,7 +54,7 @@ class ProjectCreation(BaseConfig):
         # reverse it to [Z, Y, X] to match syGlass
         img_res = img_res[::-1] 
         
-        project.set_voxel_dimensions(img_res, dtype=float))
+        project.set_voxel_dimensions(img_res, dtype=float)
         
         return project_file_location
     

--- a/tools/project_creation.py
+++ b/tools/project_creation.py
@@ -54,7 +54,7 @@ class ProjectCreation(BaseConfig):
         # reverse it to [Z, Y, X] to match syGlass
         img_res = img_res[::-1] 
         
-        project.set_voxel_dimensions(img_res, dtype=float)
+        project.set_voxel_dimensions(img_res)
     
     def create_base_project(self, first_img_image):
         proj_file_location = r'{}'.format(self.output_path)


### PR DESCRIPTION
I had to make some edits in `tools/project_creation.py` in order to get project creation from volume working:

- Removed extraneous parenthesis that caused a mismatch error (148ac32746c69189317428bd4bc53bd7a58d81a8)
- Moved project creation and setting of voxel dimensions into separate functions; the newly created project object must be released by scope before being reopened and having voxel dimensions set to avoid a `Cannot init DB` error from the syGlass side (8b7ef5756f69710dafe9bb735fb9d2f13dd66dde)
- Added missing `CloudVolume` import and protocol & bucket prefixes to image URI (8d1439e3dc608035c748feae49b1cd8372208062)
- Removed a `dtype` argument that is unexpected for the syGlass `set_voxel_dimensions` function (69848c2ffceb3cb194ec92ef17cd071c5b811bad)

Below is the content of the `config.ini` file used in the corresponding tests:

```
[DEFAULT]
img_uri = witvliet2020/Dataset_8/em
img_res = 0 
seg = True 
seg_uri = witvliet2020/Dataset_8_Segmentation/segmentation
seg_res = 0  
x_dimensions = 18000:22000
y_dimensions = 8000:12000
z_dimensions = 200:400
output_path = .\witvliet2020
CAVEclient = 
mesh_ids = [133,169,80,184,70,112,151,42,84,51,116,148,76,187,4,66,10,170,127,45,25,111,131,123,211,179,14,150,78,140,27,193,60,113,53,172,182,6,109,104,114,145,108,26,216,213,91,30,214,212,205,68,110,37,217,215,203,156,97,102,128,71,135,134,87,15,98,154,190,130,144,56,8,177,85,209,165,178,3,126,207,137,36,125,143,138,52,146,149,69,188,47,61,82,180,28,175,31,21,88,48,195,152,210,41,34,202,121,164,198,176,67,218,227,228,229,230,231,232,233,234,235,236,219,220,221,222,223,224,225,226,101,64,171,103,20,5,13,19,197,105,39,136,96,161,200,201,16,115,118,94,208,119,124,9,12,185,204,117,32,90,206,166,189,99,55,100,81,79,7,29,40,199,22,92,49,1,59,74,142,160,2,147,73,75,159,191,139,83,120,65,183,122,157,162,23,43,89,17,11,50,77,86,141,158,44,93,129,174,46,54,106,155,192,35,196,153,18,58,168,62,186,95,173,163,24,167,38,57,132,107,33,72,181,63,194]
mesh_uri = mesh/witvliet2020/Dataset_8_Mesh
project_name = witvliet2020
syglass_directory = C:/Program Files/syGlass/bin
shader_settings_to_load_path =
annotation_csv_file_path =
trace_file_path =
```