### PR TITLE
Adds .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# image and mesh files
+*.tiff
+*.obj
+
+# syglass project files
+*.syg
+*.sym
+*.syk
+*.bak
+*.mib
+log.txt
+
+# compiled python files
+*.pyc


### PR DESCRIPTION
Adds a `.gitignore` which ignores file types that show up in large numbers during use of bossVR and that generally shouldn't be committed.