### PR TITLE
Fix neuroglancer legacy meshes

### DIFF
--- a/tools/mesh_download.py
+++ b/tools/mesh_download.py
@@ -36,7 +36,14 @@ class MeshDownload(BaseConfig):
         print(f"{len(self.mesh_ids)} meshes have been downloaded to {mesh_file_location}")
 
     def download_meshes_cv(self, mesh_file_location):
-        mesh_vol = CloudVolume(f"s3://bossdb-open-data/{self.mesh_uri}", fill_missing=True, use_https=True)
+        try:
+            mesh_vol = CloudVolume(f"s3://bossdb-open-data/{self.mesh_uri}", fill_missing=True, use_https=True)
+        except KeyError:
+            # If this is caught, most likely means meshes are neuroglancer legacy formatted
+            mesh_vol_uri = os.path.dirname(self.mesh_uri)
+            mesh_vol_name = os.path.basename(self.mesh_uri)
+            mesh_vol = CloudVolume(f"s3://bossdb-open-data/{mesh_vol_uri}", fill_missing=True, use_https=True)
+            mesh_vol.info["mesh"] = mesh_vol_name
 
         # specify where to save mesh objs
         os.makedirs(mesh_file_location, exist_ok=True)


### PR DESCRIPTION
Closes #10 

The problem stems from neuroglancer legacy formatted meshes having an `info` file containing only
```
{"@type": "neuroglancer_legacy_mesh"}
```
In Neuroglancer it is assumed that the `info` file one directory up will be properly formatted and include a field "mesh" which contains the subdirectory path for the meshes. This PR catches this specific error and handles it by loading the volume the way Neuroglancer would, from one directory up, and then editing the `info` object in memory to contain the mesh subdirectory specified by the user. 

Tested with up-to-date Kasthuri meshes using the `config.ini` shipped with this repo, and also with the neuroglancer legacy formatted Witvliet meshes using the `config.ini` included in #10. 